### PR TITLE
`gitsum` analysis

### DIFF
--- a/R/00-setup-r-env.R
+++ b/R/00-setup-r-env.R
@@ -1,0 +1,23 @@
+# Install any remote dependencies that are required by R, and which are not
+# available on conda
+
+###############################################################################
+
+main <- function(remotes) {
+  for (package in remotes) {
+    devtools::install_github(package, dependencies = FALSE)
+  }
+}
+
+###############################################################################
+
+library("here")
+library("devtools")
+
+source(here("R", "config.R"))
+
+main(
+  remotes = config[["remotes"]]
+)
+
+###############################################################################

--- a/R/07-gitsum-analysis.R
+++ b/R/07-gitsum-analysis.R
@@ -1,0 +1,52 @@
+###############################################################################
+
+get_gitsum_results <- function(repo_details) {
+   Map(
+    function(pkg, path) {
+      gitsum::init_gitsum(path, over_write = TRUE)
+
+      gitsum::parse_log_detailed(path) %>%
+        gitsum::unnest_log() %>%
+        gitsum::set_changed_file_to_latest_name() %>%
+        dplyr::filter(stringr::str_starts(changed_file, "R/"))
+    },
+    repo_details[["package"]],
+    repo_details[["local_repo"]]
+  )
+}
+
+format_gitsum <- function(list_of_dfs) {
+  dplyr::bind_rows(list_of_dfs, .id = "package")
+}
+
+###############################################################################
+
+main <- function(repo_details_file, results_file) {
+  repo_details <- read_repo_details(repo_details_file)
+
+  gitsum_results <- repo_details %>%
+    get_gitsum_results() %>%
+    format_gitsum()
+
+  readr::write_tsv(gitsum_results, results_file)
+}
+
+###############################################################################
+
+# script
+
+###############################################################################
+
+library("here")
+source(here("R", "utils.R"))
+source(here("R", "config.R"))
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "gitsum", "magrittr", "readr", "stringr", "tidyr"))
+
+main(
+  repo_details_file = config[["repo_details_file"]],
+  results_file = config[["all_pkg_gitsum_file"]]
+)
+
+###############################################################################

--- a/R/config.R
+++ b/R/config.R
@@ -33,6 +33,13 @@ config <- list(
   # fail (because the cloc-results are read in as .csv format)
   drop = c(
     "logging", "R.oo"
+  ),
+
+  # which packages should be installed from github?
+  # - any dependencies for these packages should already be installed to the
+  # conda environment
+  remotes = c(
+    "hrbrmstr/cloc", "lorenzwalthert/gitsum"
   )
 )
 

--- a/R/config.R
+++ b/R/config.R
@@ -46,8 +46,8 @@ config <- list(
 config <- append(
   config,
   list(
-    # The next three files only store data for the repositories that we are
-    # going to analyse here
+    # These files only store data for the repositories that we are going to
+    # analyse here
     repo_details_file = file.path(
       config[["results_dir"]], "dev-pkg-repositories.tsv"
     ),
@@ -59,6 +59,9 @@ config <- append(
     ),
     all_pkg_cloc_file = file.path(
       config[["results_dir"]], "dev-pkg-cloc.tsv"
+    ),
+    all_pkg_gitsum_file = file.path(
+      config[["results_dir"]], "dev-pkg-gitsum.tsv"
     )
   )
 )

--- a/README.md
+++ b/README.md
@@ -16,14 +16,10 @@ Activate the environment
 conda activate code_as_data
 ```
 
-Some of the packages used in this project are not on anaconda, CRAN or
-Bioconductor
-
-```
-# In R:
-library(devtools)
-devtools::install_github("hrbmstr/cloc", dependencies = FALSE)
-```
+Some of the R packages used in this project are not on anaconda, CRAN or
+Bioconductor. These are installed by the script `R/00-setup-env.R`. See
+the 'remotes' entry in the config for details of the packages that are
+installed in this way.
 
 ----
 
@@ -36,7 +32,7 @@ conda activate code_as_data
 ```
 
 Then use the bash script to run the workflow (this will make any results
-directories that are missing)
+directories that are missing and install any non-conda dependencies)
 
 ```
 ./run_me.sh

--- a/envs/environment.yml
+++ b/envs/environment.yml
@@ -139,6 +139,7 @@ dependencies:
   - r-lazyeval=0.2.2
   - r-lifecycle=0.1.0
   - r-lintr=2.0.0
+  - r-lubridate=1.7.4
   - r-magrittr=1.5
   - r-markdown=1.1
   - r-mass=7.3_51.4

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -185,6 +185,7 @@ https://conda.anaconda.org/conda-forge/noarch/r-desc-1.2.0-r35h6115d3f_1002.tar.
 https://conda.anaconda.org/conda-forge/noarch/r-here-0.1-r35h6115d3f_1002.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.5.1-r35h6115d3f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.26-r35h6115d3f_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/r-lubridate-1.7.4-r35h0357c0b_1002.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.8_29-r35hcdcec82_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/r-openssl-1.4.1-r35h9c8475f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/r-promises-1.1.0-r35h0357c0b_0.tar.bz2

--- a/run_me.sh
+++ b/run_me.sh
@@ -14,6 +14,10 @@ for dir in "results" "results/packages"; do
   if [[ ! -d "${dir}" ]]; then mkdir "${dir}"; fi
 done
 
+# Install any non-conda R-dependencies
+
+Rscript R/00-setup-env.R
+
 # Run each step of the analysis:
 
 Rscript R/01-get-devtools-cran-table.R
@@ -28,3 +32,6 @@ Rscript R/05-collapse-benchmarks.R
 
 Rscript R/06-cloc-analysis.R
 
+# Make the report
+
+echo "TODO: compile an Rmarkdown report of the results" >&2

--- a/run_me.sh
+++ b/run_me.sh
@@ -32,6 +32,8 @@ Rscript R/05-collapse-benchmarks.R
 
 Rscript R/06-cloc-analysis.R
 
+Rscript R/07-gitsum-analysis.R
+
 # Make the report
 
 echo "TODO: compile an Rmarkdown report of the results" >&2


### PR DESCRIPTION
Code to install and run gitsum on a set of downloaded repositories.

Uses gitsum's detailed log and unnests this so that there is a single line for each file that is changed in each commit

Also
- add a script to install non-conda dependencies (cloc / gitsum) from github
- update README (user no longer needs to install github dependencies)
