### PR TITLE
paths in `conf/config.yaml` should be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ First activate the conda environment (if you haven't already)
 conda activate code_as_data
 ```
 
-Then use the bash script to run the workflow (this will make any results
-directories that are missing and install any non-conda dependencies)
+Then use the bash script to run the workflow (this will make any results / data
+directories that are missing and install any non-conda dependencies).
 
 ```
 ./run_me.sh
 ```
 
+If you want the data or results to be stored to a specific location, set up
+links to these positions before running `run_me.sh`.

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -4,14 +4,16 @@
 
 # -- Directories and filepaths
 
+# Paths should be specified relative to the repository root
+
 # Store results summaries here
-results_dir: results
+results_dir: "results"
 
 # Store results for individual packages in subdirs of this:
-pkg_results_dir: results/packages
+pkg_results_dir: "results/packages"
 
 # Save the raw repositories in subdirs of this:
-repo_dir: ~/temp/dev-tools-analysis
+repo_dir: "data/packages"
 
 # -- -- results files
 

--- a/run_me.sh
+++ b/run_me.sh
@@ -14,9 +14,9 @@ fi
 
 # Ensure the results directories are set up
 
-for key in "results_dir" "pkg_results_dir"; do
+for key in "results_dir" "pkg_results_dir" "repo_dir"; do
   dir="$(cat "${config_file}" | shyaml get-value "${key}")"
-  if [[ ! -d ${dir} ]]; then mkdir ${dir}; fi
+  if [[ ! -d ${dir} ]]; then mkdir -p ${dir}; fi
 done
 
 # Install any non-conda R-dependencies


### PR DESCRIPTION
Also:

- use `data/packages` as default storage for downloaded repos

- ensure `config::repo_dir` exists, or create it, during setup

- explain that setting up links is the users responsibility in README