### PR TITLE
Use commit stamped remotes

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -46,10 +46,21 @@ task_view_url: https://raw.githubusercontent.com/ropensci/PackageDevelopment/mas
 drop: ["logging", "R.oo", "rscala"]
 
 # Which packages must be installed from github for the analyses to be able to
-# run? ["gh_username/repo_name", ...]
+# run?
 # - any dependencies of these packages should already be installed to the conda
 # environment
-remotes: ["hrbrmstr/cloc", "lorenzwalthert/gitsum"]
+# - we are using the dev version of {dupree} in case any improvements to that
+# package are discovered during development of this project
+remotes:
+  - cloc:
+    repo: "hrbrmstr/cloc"
+    commit: "f1bcd53"
+  - gitsum:
+    repo: "lorenzwalthert/gitsum"
+    commit: "bd98c22"
+  - dupree:
+    repo: "russHyde/dupree"
+    commit: "3138100"
 
 # ===================== #
 

--- a/envs/environment.yml
+++ b/envs/environment.yml
@@ -107,7 +107,6 @@ dependencies:
   - r-digest=0.6.23
   - r-dplyr=0.8.3
   - r-dt=0.10
-  - r-dupree=0.2.0
   - r-ellipsis=0.3.0
   - r-evaluate=0.14
   - r-fansi=0.4.0

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -239,7 +239,6 @@ https://conda.anaconda.org/conda-forge/noarch/r-lintr-2.0.0-r35h6115d3f_0.tar.bz
 https://conda.anaconda.org/conda-forge/linux-64/r-readxl-1.3.1-r35h0357c0b_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.0.0-r35h0357c0b_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-dt-0.10-r35h6115d3f_0.tar.bz2
-https://conda.anaconda.org/russh/linux-64/r-dupree-0.2.0-r35h6115d3f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-janitor-1.2.0-r35h6115d3f_1.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-sparklyr-1.0.5-r35h6115d3f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/r-devtools-2.2.1-r35h6115d3f_0.tar.bz2

--- a/scripts/00-setup-r-env.R
+++ b/scripts/00-setup-r-env.R
@@ -25,8 +25,10 @@ define_parser <- function() {
       c("--config"), type = "character",
       help = paste(
         "A .yaml file containing the configuration details for the workflow.",
-        "Any 'userName/repo' repository in it's `remotes` field will be",
-        "installed."
+        "Any repos in the `remotes` field will be installed.",
+        "Each entry of the `remotes` field should have a `repo` and an",
+        "optional `commit` entry (if no commit, current master will be used).",
+        "`repo` should be of the form 'userName/repoName'."
       )
     )
 }
@@ -35,7 +37,15 @@ define_parser <- function() {
 
 main <- function(remotes) {
   for (package in remotes) {
-    devtools::install_github(package, dependencies = FALSE)
+    repo_stub <- package[["repo"]]
+    commit <- if ("commit" %in% names(package)) {
+      package[["commit"]]
+    } else {
+      "master"
+    }
+    devtools::install_github(
+      repo = repo_stub, dependencies = FALSE, ref = commit
+    )
   }
 }
 


### PR DESCRIPTION
Github packages (cloc, gitsum and now dupree) are now installed from a
specific commit-stamp.

The config has changed, all entries in `remotes` must have a "repo"
(ownerName/repoName) and (optional) "config" entry ("master" is assumed
if no "config" entry is present).

Also,
- {dupree} was bumped to assert R package structure before analysing a repo