### PR TITLE
nest package-pooled results file defs in 'pooled_results' field

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -19,9 +19,11 @@ repo_dir: "data/packages"
 
 repo_details_file:        "results/dev-pkg-repositories.tsv"
 cran_details_file:        "results/dev-pkg-table.tsv"
-all_pkg_benchmarks_file:  "results/dev-pkg-benchmarks.tsv"
-all_pkg_cloc_file:        "results/dev-pkg-cloc.tsv"
-all_pkg_gitsum_file:      "results/dev-pkg-gitsum.tsv"
+
+pooled_results:
+  dupree_benchmarks: "results/dev-pkg-benchmarks.tsv"
+  cloc:              "results/dev-pkg-cloc.tsv"
+  gitsum:            "results/dev-pkg-gitsum.tsv"
 
 # ===================== #
 

--- a/run
+++ b/run
@@ -36,9 +36,9 @@ task_view_url="$(yaml_value "${config_file}" "task_view_url")"
 # Files constructed by the called scripts
 cran_table="$(yaml_value "${config_file}" "cran_details_file")"
 repo_details="$(yaml_value "${config_file}" "repo_details_file")"
-dupree_benchmarks="$(yaml_value "${config_file}" "all_pkg_benchmarks_file")"
-cloc_table="$(yaml_value "${config_file}" "all_pkg_cloc_file")"
-gitsum_table="$(yaml_value "${config_file}" "all_pkg_gitsum_file")"
+dupree_benchmarks="$(yaml_value "${config_file}" "pooled_results.dupree_benchmarks")"
+cloc_table="$(yaml_value "${config_file}" "pooled_results.cloc")"
+gitsum_table="$(yaml_value "${config_file}" "pooled_results.gitsum")"
 
 # Parent directories for package-specific:
 # - local-storage of the github repos


### PR DESCRIPTION
Results files for package-pooled analyses were previously defined in the config as `all_pkg_benchmarks_file`, `all_pkg_cloc_file`, `all_pkg_gitsum_file`.

Modified the config, and `run` script to encapsulate these package-pooled filenames into a nested `pooled_results` field.