### PR TITLE
Add cross-pkg gitsum analysis to app

### DIFF
--- a/shiny/R/import_pipeline_results.R
+++ b/shiny/R/import_pipeline_results.R
@@ -1,0 +1,18 @@
+library(dplyr)
+library(readr)
+
+import_pipeline_results <- function(cloc_file, gitsum_file) {
+  stopifnot(file.exists(cloc_file))
+  stopifnot(file.exists(gitsum_file))
+
+  cloc <- readr::read_tsv(cloc_file)
+
+  gitsum <- readr::read_tsv(gitsum_file, col_types = readr::cols()) %>%
+    # for consistency with cloc 'filename' column
+    dplyr::rename(filename = changed_file)
+
+  list(
+    cloc = cloc,
+    gitsum = gitsum
+  )
+}

--- a/shiny/R/summarise_by_package.R
+++ b/shiny/R/summarise_by_package.R
@@ -1,0 +1,25 @@
+library(dplyr)
+
+summarise_cloc <- function(df) {
+  # collapses the raw cloc dataset (which has one row per file) by package name
+  # taking the total of the lines of code
+  df %>%
+    dplyr::group_by(package) %>%
+    dplyr::summarise_if(is.numeric, sum)
+}
+
+summarise_gitsum <- function(df) {
+  df %>%
+    dplyr::group_by(package) %>%
+    dplyr::summarise(
+      n_commits = dplyr::n_distinct(hash),
+      n_contributors = dplyr::n_distinct(author_email)
+    )
+}
+
+summarise_by_package <- function(cloc_data, gitsum_data) {
+  cloc <- summarise_cloc(cloc_data)
+  gitsum <- summarise_gitsum(gitsum_data)
+
+  dplyr::left_join(gitsum, cloc)
+}

--- a/shiny/R/ui.R
+++ b/shiny/R/ui.R
@@ -6,6 +6,7 @@ footer <- function() {
   gh_links <- list(
     cod = tags$a(href = glue("{gh}/russHyde/code_as_data"), "code_as_data"),
     cloc = tags$a(href = glue("{gh}/hrbrmstr/cloc"), "cloc"),
+    gitsum = tags$a(href = glue("{gh}/lorenzwalthert/gitsum"), "gitsum"),
     me = tags$a(href = glue("{gh}/russHyde"), "Russ Hyde"),
     shiny = tags$a(href = glue("{gh}/rstudio/shiny"), "Shiny")
   )
@@ -19,7 +20,7 @@ footer <- function() {
         style = "float:right",
         p("Made by ", gh_links$me, " using ", gh_links$shiny),
         p("Code at github: ", gh_links$cod),
-        p("Analysis packages: ", gh_links$cloc)
+        p("Analysis packages: ", gh_links$cloc, ", ", gh_links$gitsum)
       )
     )
   )

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -16,14 +16,28 @@ files <- list(
   gitsum = file.path(dirs[["app_data"]], "dev-pkg-gitsum.tsv")
 )
 
+# TODO: fix the y-axis label of the barplot to use the label in this vector
+pkg_statistics <- c(
+  "Lines of Code" = "loc",
+  "Number of Commits" = "n_commits",
+  "Number of Contributors" = "n_contributors"
+)
+
 # Helper functions
 
+#' Takes the package-summarised dataset and produces a barplot, with packages
+#' ordered by a user-selected statistic (lines of code, number of commits
+#' etc)
+#' @param df   The data-frame. This should contain columns (package, n_commits,
+#' n_contributors, loc, ...)
+#' @param column   String. Which of the columns within the dataframe should a
+#'   barplot be made for?
 barplot_by_package <- function(df, column) {
-  # takes the package-summarised dataset and produces a barplot, with packages
-  # ordered by a user-selected statistic (lines of code, number of commits etc)
   df %>%
-    mutate(package = forcats::fct_reorder(package, {{ column }}, .desc = TRUE)) %>%
-    ggplot(aes(x = package, y = {{ column }})) +
+    mutate(
+      package = forcats::fct_reorder(package, .data[[column]], .desc = TRUE)
+    ) %>%
+    ggplot(aes(x = package, y = .data[[column]])) +
     geom_bar(stat = "identity") +
     guides(x = guide_axis(angle = 90))
 }
@@ -33,7 +47,16 @@ barplot_by_package <- function(df, column) {
 ui <- fluidPage(
   titlePanel("Code as data"),
   dataTableOutput("package_summary_table"),
-  plotOutput("pkg_summary_barplot"),
+  fluidRow(
+    column(
+      3,
+      selectInput(
+        "chosen_stat",
+        "Choose a statistic to display",
+        choices = pkg_statistics)
+    ),
+    column(9, plotOutput("pkg_summary_barplot"))
+  ),
   footer()
 )
 
@@ -56,11 +79,9 @@ server <- function(input, output, session) {
     options = list(pageLength = 5)
   )
 
-  # TODO: allow user to choose whether to make barplot of: loc, n_commits,
-  # n_contributors etc
   output$pkg_summary_barplot <- renderPlot(
     data_by_package() %>%
-      barplot_by_package(loc)
+      barplot_by_package(input$chosen_stat)
   )
 }
 

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -19,22 +19,6 @@ files <- list(
 
 # Helper functions
 
-import_pipeline_results <- function(cloc_file, gitsum_file) {
-  stopifnot(file.exists(cloc_file))
-  stopifnot(file.exists(gitsum_file))
-
-  cloc <- readr::read_tsv(cloc_file)
-
-  gitsum <- readr::read_tsv(gitsum_file, col_types = readr::cols()) %>%
-    # for consistency with cloc 'filename' column
-    dplyr::rename(filename = changed_file)
-
-  list(
-    cloc = cloc,
-    gitsum = gitsum
-  )
-}
-
 summarise_cloc <- function(df) {
   # collapses the raw cloc dataset (which has one row per file) by package name
   # taking the total of the lines of code

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -73,7 +73,7 @@ cloc_barplot <- function(df) {
 
 ui <- fluidPage(
   titlePanel("Code as data"),
-  tableOutput("cloc_summary_table"),
+  dataTableOutput("package_summary_table"),
   plotOutput("cloc_summary_barplot"),
   footer()
 )
@@ -92,10 +92,9 @@ server <- function(input, output, session) {
     )
   )
 
-  output$cloc_summary_table <- renderTable(
-    data_by_package() %>%
-      select(package, loc, blank_lines, comment_lines) %>%
-      head(n = 10)
+  output$package_summary_table <- renderDataTable(
+    data_by_package(),
+    options = list(pageLength = 5)
   )
 
   output$cloc_summary_barplot <- renderPlot(

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -18,12 +18,12 @@ files <- list(
 
 # Helper functions
 
-cloc_barplot <- function(df) {
-  # takes the package-summarised cloc dataset and produces a barplot, with
-  # packages ordered by the total number of actual lines of code
+barplot_by_package <- function(df, column) {
+  # takes the package-summarised dataset and produces a barplot, with packages
+  # ordered by a user-selected statistic (lines of code, number of commits etc)
   df %>%
-    mutate(package = forcats::fct_reorder(package, loc, .desc = TRUE)) %>%
-    ggplot(aes(x = package, y = loc)) +
+    mutate(package = forcats::fct_reorder(package, {{ column }}, .desc = TRUE)) %>%
+    ggplot(aes(x = package, y = {{ column }})) +
     geom_bar(stat = "identity") +
     guides(x = guide_axis(angle = 90))
 }
@@ -33,7 +33,7 @@ cloc_barplot <- function(df) {
 ui <- fluidPage(
   titlePanel("Code as data"),
   dataTableOutput("package_summary_table"),
-  plotOutput("cloc_summary_barplot"),
+  plotOutput("pkg_summary_barplot"),
   footer()
 )
 
@@ -56,10 +56,11 @@ server <- function(input, output, session) {
     options = list(pageLength = 5)
   )
 
-  output$cloc_summary_barplot <- renderPlot(
+  # TODO: allow user to choose whether to make barplot of: loc, n_commits,
+  # n_contributors etc
+  output$pkg_summary_barplot <- renderPlot(
     data_by_package() %>%
-      dplyr::select(package, loc, blank_lines, comment_lines) %>%
-      cloc_barplot()
+      barplot_by_package(loc)
   )
 }
 

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -19,30 +19,6 @@ files <- list(
 
 # Helper functions
 
-summarise_cloc <- function(df) {
-  # collapses the raw cloc dataset (which has one row per file) by package name
-  # taking the total of the lines of code
-  df %>%
-    group_by(package) %>%
-    summarise_if(is.numeric, sum)
-}
-
-summarise_gitsum <- function(df) {
-  df %>%
-    group_by(package) %>%
-    summarise(
-      n_commits = n_distinct(hash),
-      n_contributors = n_distinct(author_email)
-    )
-}
-
-summarise_by_package <- function(cloc_data, gitsum_data) {
-  cloc <- summarise_cloc(cloc_data)
-  gitsum <- summarise_gitsum(gitsum_data)
-
-  dplyr::left_join(gitsum, cloc)
-}
-
 cloc_barplot <- function(df) {
   # takes the package-summarised cloc dataset and produces a barplot, with
   # packages ordered by the total number of actual lines of code

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -4,7 +4,6 @@ library(dplyr)
 library(forcats)
 library(ggplot2)
 library(magrittr)
-library(readr)
 
 # Constants
 
@@ -23,7 +22,7 @@ cloc_barplot <- function(df) {
   # takes the package-summarised cloc dataset and produces a barplot, with
   # packages ordered by the total number of actual lines of code
   df %>%
-    mutate(package = fct_reorder(package, loc, .desc = TRUE)) %>%
+    mutate(package = forcats::fct_reorder(package, loc, .desc = TRUE)) %>%
     ggplot(aes(x = package, y = loc)) +
     geom_bar(stat = "identity") +
     guides(x = guide_axis(angle = 90))
@@ -59,7 +58,7 @@ server <- function(input, output, session) {
 
   output$cloc_summary_barplot <- renderPlot(
     data_by_package() %>%
-      select(package, loc, blank_lines, comment_lines) %>%
+      dplyr::select(package, loc, blank_lines, comment_lines) %>%
       cloc_barplot()
   )
 }

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -47,15 +47,15 @@ barplot_by_package <- function(df, column) {
 ui <- fluidPage(
   titlePanel("Code as data"),
   dataTableOutput("package_summary_table"),
-  fluidRow(
-    column(
-      3,
+  sidebarLayout(
+    sidebarPanel(
       selectInput(
-        "chosen_stat",
-        "Choose a statistic to display",
-        choices = pkg_statistics)
+        "chosen_stat", "Choose a statistic to display", choices = pkg_statistics
+      )
     ),
-    column(9, plotOutput("pkg_summary_barplot"))
+    mainPanel(
+      plotOutput("pkg_summary_barplot")
+    )
   ),
   footer()
 )


### PR DESCRIPTION
User
- can select whether to make barplot of number of lines-of-code, contributors or commits
- can dynamically sort the summary-table (eg, order packages by lines-of-code)
- gitsum statistics (number of commits, number of contributors) are added to the summary-table

Refactors data-import and data-summarising functions into ./R/