### PR TITLE
Data is constant

### DIFF
--- a/shiny/app.R
+++ b/shiny/app.R
@@ -23,6 +23,11 @@ pkg_statistics <- c(
   "Number of Contributors" = "n_contributors"
 )
 
+raw_data <- import_pipeline_results(
+  cloc_file = files[["cloc"]],
+  gitsum_file = files[["gitsum"]]
+)
+
 # Helper functions
 
 #' Takes the package-summarised dataset and produces a barplot, with packages
@@ -61,17 +66,8 @@ ui <- fluidPage(
 )
 
 server <- function(input, output, session) {
-  data <- reactive(
-    import_pipeline_results(
-      cloc_file = files[["cloc"]],
-      gitsum_file = files[["gitsum"]]
-    )
-  )
-
   data_by_package <- reactive(
-    summarise_by_package(
-      data()[["cloc"]], data()[["gitsum"]]
-    )
+    summarise_by_package(raw_data[["cloc"]], raw_data[["gitsum"]])
   )
 
   output$pkg_summary_table <- renderDataTable(

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -46,7 +46,7 @@ barplot_by_package <- function(df, column) {
 
 ui <- fluidPage(
   titlePanel("Code as data"),
-  dataTableOutput("package_summary_table"),
+  dataTableOutput("pkg_summary_table"),
   sidebarLayout(
     sidebarPanel(
       selectInput(
@@ -74,7 +74,7 @@ server <- function(input, output, session) {
     )
   )
 
-  output$package_summary_table <- renderDataTable(
+  output$pkg_summary_table <- renderDataTable(
     data_by_package(),
     options = list(pageLength = 5)
   )


### PR DESCRIPTION
The raw data used in the app (from cloc and gitsum analyses) is constant.
It was initially imported as part of a reactive expression.
Now it is imported as a global constant.

Also renamed an output ID so that barplot and summary-table have consistent name `pkg_summary_[barplot|table]`