### PR TITLE
Add spinners

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -717,6 +717,13 @@
       "Repository": "CRAN",
       "Hash": "6e3b6ae7fe02b5859e4bb277f218b8ae"
     },
+    "shinycssloaders": {
+      "Package": "shinycssloaders",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f39bb3c44a9b496723ec7e86f9a771d8"
+    },
     "snakecase": {
       "Package": "snakecase",
       "Version": "0.11.0",

--- a/shiny/R/crossPackageReport.R
+++ b/shiny/R/crossPackageReport.R
@@ -2,6 +2,7 @@ library(forcats)
 library(ggplot2)
 library(magrittr)
 library(rlang)
+library(shinycssloaders)
 
 # Helper functions
 
@@ -46,7 +47,9 @@ scatter_by_package <- function(df, x, y, labeller = NULL) {
 
 crossPackageReportUI <- function(id, pkg_statistics) {
   tagList(
-    dataTableOutput(NS(id, "pkg_summary_table")),
+    shinycssloaders::withSpinner(
+      dataTableOutput(NS(id, "pkg_summary_table"))
+    ),
     sidebarLayout(
       sidebarPanel(
         selectInput(
@@ -56,10 +59,14 @@ crossPackageReportUI <- function(id, pkg_statistics) {
         )
       ),
       mainPanel(
-        plotOutput(NS(id, "pkg_summary_barplot"))
+        shinycssloaders::withSpinner(
+          plotOutput(NS(id, "pkg_summary_barplot"))
+        )
       )
     ),
-    plotOutput(NS(id, "pkg_loc_vs_commits"))
+    shinycssloaders::withSpinner(
+      plotOutput(NS(id, "pkg_loc_vs_commits"))
+    )
   )
 }
 

--- a/shiny/R/singlePackageReport.R
+++ b/shiny/R/singlePackageReport.R
@@ -23,8 +23,6 @@ singlePackageReportServer <- function(id, raw_data) {
       purrr::map(raw_data, dplyr::filter, package == input$chosen_pkg)
     )
 
-    output$file_change_table <- renderDataTable(pkg_data()[["gitsum"]])
-
     output$file_change_plot <- renderPlot(
       pkg_data()[["gitsum"]] %>%
         plot_file_commits_by_author()

--- a/shiny/R/singlePackageReport.R
+++ b/shiny/R/singlePackageReport.R
@@ -3,6 +3,7 @@ library(forcats)
 library(ggplot2)
 library(magrittr)
 library(purrr)
+library(shinycssloaders)
 
 singlePackageReportUI <- function(id, pkgs) {
   tagList(
@@ -11,7 +12,9 @@ singlePackageReportUI <- function(id, pkgs) {
         selectInput(NS(id, "chosen_pkg"), "Choose a package", choices = pkgs)
       ),
       mainPanel(
-        plotOutput(NS(id, "file_change_plot"))
+        shinycssloaders::withSpinner(
+          plotOutput(NS(id, "file_change_plot"))
+        )
       )
     )
   )


### PR DESCRIPTION
Fix #48 
Adds spinners to all outputs (tables / figures) using {shinycssloaders}