### PR TITLE
fix: use ropensci-archive to access the package dev .ctv file

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -34,7 +34,7 @@ reports: ["doc/experiments.html"]
 
 # A CRAN-task-view style document that includes a range of package-development
 # tools
-task_view_url: https://raw.githubusercontent.com/ropensci/PackageDevelopment/master/PackageDevelopment.ctv
+task_view_url: https://raw.githubusercontent.com/ropensci-archive/PackageDevelopment/master/PackageDevelopment.ctv
 
 # Which packages are found on CRAN and in the task-view file, but should not be
 # analysed here:


### PR DESCRIPTION
ROpenSci archived the "PackageDevelopment" CRAN Task View in May 2022.
The URL used for accessing the .ctv file for this Task View has changed (to https://github.com/ropensci-archive/PackageDevelopment)

Relevant to the archiving of that repo, the {ctv} R package has changed the format it uses in version 0.9-0 (Dec 2019).
The task views are now in markdown, rather than xml.
Hence, the .ctv format version of the ropensci package-dev list is now unparseable by {ctv}. However, we weren't using ctv to parse that file, we were using bespoke xml.

Our bespoke xml parsing still works fine for the package development .ctv file.