### PR TITLE
Move gitsum analysis to {codeAsData}

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -212,17 +212,24 @@
     },
     "codeAsData": {
       "Package": "codeAsData",
-      "Version": "0.1.2",
+      "Version": "0.1.3",
       "Source": "GitHub",
+      "Remotes": "lorenzwalthert/gitsum",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "codeAsData",
       "RemoteUsername": "russHyde",
       "RemoteRef": "HEAD",
-      "RemoteSha": "e2076f61f93a712f145ee8f482766e20f9c8114b",
-      "Hash": "becc156e08ea2992f7a1c5ca7dfc08b3",
+      "RemoteSha": "18bbd67d8c6eece1c62e209e7942e354de0b0f18",
+      "Hash": "ba9649b08408b36020bda374d670cf85",
       "Requirements": [
-        "ctv"
+        "ctv",
+        "dplyr",
+        "gitsum",
+        "readr",
+        "rlang",
+        "stringr",
+        "tibble"
       ]
     },
     "codetools": {
@@ -340,10 +347,10 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.0",
+      "Version": "1.1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d3c34618017e7ae252d46d79a1b9ec32",
+      "Repository": "CRAN",
+      "Hash": "eb5742d256a0d9306d85ea68756d8187",
       "Requirements": [
         "R6",
         "cli",
@@ -562,12 +569,11 @@
     },
     "hms": {
       "Package": "hms",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "41100392191e1244b887878b533eea91",
+      "Repository": "CRAN",
+      "Hash": "b59377caa7ed00fa41808342002138f9",
       "Requirements": [
-        "ellipsis",
         "lifecycle",
         "pkgconfig",
         "rlang",
@@ -853,10 +859,10 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.8.1",
+      "Version": "1.9.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f2316df30902c81729ae9de95ad5a608",
+      "Repository": "CRAN",
+      "Hash": "15da5a8412f317beeee6175fbc76f4bb",
       "Requirements": [
         "cli",
         "fansi",
@@ -1259,10 +1265,10 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.2.0",
+      "Version": "3.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "37695ff125982007d42a59ad10982ff2",
+      "Hash": "a84e2cc86d07289b3b6f5069df7a004c",
       "Requirements": [
         "fansi",
         "lifecycle",
@@ -1349,10 +1355,10 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.5.2",
+      "Version": "0.6.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e4ffa94ceed5f124d429a5a5f0f5b378",
+      "Repository": "CRAN",
+      "Hash": "06eceb3a5d716fd0654cc23ca3d71a99",
       "Requirements": [
         "cli",
         "glue",

--- a/scripts/06-gitsum-analysis.R
+++ b/scripts/06-gitsum-analysis.R
@@ -4,7 +4,7 @@
 
 # pkgs require for running the script
 general_pkgs <- c("here", "magrittr", "optparse")
-pkgs <-  c(general_pkgs, "dplyr", "gitsum", "readr", "stringr", "tibble")
+pkgs <-  c(general_pkgs, "codeAsData")
 
 for (pkg in pkgs) {
   suppressPackageStartupMessages(
@@ -48,22 +48,19 @@ define_parser <- function() {
 
 ###############################################################################
 
-get_gitsum_results <- function(path, .package) {
-  gitsum::init_gitsum(path, over_write = TRUE)
-
-  gitsum::parse_log_detailed(path) %>%
-    gitsum::unnest_log() %>%
-    gitsum::set_changed_file_to_latest_name() %>%
-    dplyr::filter(stringr::str_starts(changed_file, "R/")) %>%
-    tibble::add_column(package = .package, .before = 1)
-}
-
-###############################################################################
-
 main <- function(local_repo, package, results_file) {
-  gitsum_results <- get_gitsum_results(local_repo, package)
-
-  readr::write_tsv(gitsum_results, results_file)
+  # This
+  # - runs gitsum on a repo,
+  # - imports the gitsum results,
+  # - cleans them up (so there is only data for R/ files, and a single row per changed file per
+  # commit); and
+  # - exports the cleaned up data as a .tsv
+  codeAsData::run_gitsum_workflow(
+    repo_path = local_repo,
+    output_path = results_file,
+    package = package,
+    r_dir_only = TRUE
+  )
 }
 
 ###############################################################################


### PR DESCRIPTION
The script `scripts/06-gitsum-analysis.R` was generating .tsv files that couldn't be combined together.

Reason: Some git commit messages contained newline characters, and the .tsv that were generated did not quote these characters. So when those newline-mangled .tsvs were read back in (during rowbind.tsv) they had mismatched column numbers. Some rows had 29, some had less.

Of note: `readr::write_tsv()` does not use the same default `quote` argument as `readr::write_delim` (tsv uses 'none', delim uses 'needed'). A change to the default 'quote' occurred with [readr v2.0.0](https://cloud.r-project.org/web/packages/readr/news/news.html).

The entire workflow for calling {gitsum} functions has been moved into {codeAsData}. A test has been added to that package to ensure that the .tsv that is written out can also be read back in. The only relevant function is `codeAsData::run_gitsum_workflow()`. The 'quote' value is set in that function to 'needed', so the commit-messages should be stored correctly now.

Note that the snakemake pipeline runs to completion now.